### PR TITLE
Update Min Browser and add license files, add forgotten xdg-mime shim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.flatpak-builder/

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,15 @@
+Min Browser is distributed under the Apache License, Version 2.0.
+
+A copy of this license is included in the LICENSE-APACHE-2.0.txt file in this distribution.
+
+The original work for Min Browser is copyrighted by:
+Copyright 2016-2025 PalmerAL (and other contributors as noted in the Min Browser project)
+You may obtain a copy of the Apache License, Version 2.0 at:
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the Apache License, Version 2.0 is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied. See the Apache License, Version 2.0 for the
+specific language governing permissions and limitations under the
+License.

--- a/com.fightcade.Fightcade.Steamos.metainfo.xml
+++ b/com.fightcade.Fightcade.Steamos.metainfo.xml
@@ -5,11 +5,12 @@
   <name>Fightcade SteamOS Addon</name>
   <summary>Quality-of-life enhancements for Fightcade on SteamOS and Steam Deck Gaming Mode</summary>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>GPL-3.0-or-later</project_license>
+  <project_license>GPL-3.0-or-later AND Apache-2.0</project_license>
   <description>
     <p>This addon provides quality-of-life enhancements for Fightcade on SteamOS and Steam Deck Gaming Mode.</p>
     <p>It includes a workaround for external link not opening in Gaming Mode by integrating lightweight Min Browser.</p>
     <p>Note: This addon is not verified by, affiliated with, or supported by the official Fightcade team.</p>
+    <p>The Min browser component is used under the terms of the Apache License 2.0.</p>
   </description>
   <developer id="fightcade.community">
     <name>Fightcade Community</name>

--- a/com.fightcade.Fightcade.Steamos.yml
+++ b/com.fightcade.Fightcade.Steamos.yml
@@ -48,8 +48,8 @@ modules:
         dest-filename: min.deb
         only-arches:
           - x86_64
-        url: https://github.com/minbrowser/min/releases/download/v1.35.0/min-1.35.0-amd64.deb
-        sha256: 6d066842e8d0f0fa9aad0bd7cb5f56a32a67937ac75e8710c3b229cbcfc89220
+        url: https://github.com/minbrowser/min/releases/download/v1.35.1/min-1.35.1-amd64.deb
+        sha256: 9ce204945a22cb88be860dba1141c896f927982bca0940e1f08f87333a9556db
       - type: file
         path: xdg-mime.sh
       - type: file

--- a/com.fightcade.Fightcade.Steamos.yml
+++ b/com.fightcade.Fightcade.Steamos.yml
@@ -33,12 +33,16 @@ modules:
       - install -Dm755 run.sh ${FLATPAK_DEST}/bin/min-browser
       # Install xdg-mime shim
       - install -Dm755 xdg-mime.sh ${FLATPAK_DEST}/bin/xdg-mime
-      # Install the browser
+      # extract debian package
       - bsdtar -xOf min.deb data.tar.xz | bsdtar -xJf -
       - mv opt/Min min
+      # make a copy of apache 2.0 license and install the NOTICE file
+      - install -Dm644 min/resources/app/LICENSE.txt ${FLATPAK_DEST}/share/licenses/LICENSE-APACHE-2.0.txt
+      - install -Dm644 -t ${FLATPAK_DEST}/share/licenses/ NOTICE.txt
+      # Install the browser
       - mv min ${FLATPAK_DEST}/
     post-install:
-      # Install the metainfo file for the Min browser
+      # Install the metainfo file
       - >-
         install -Dm644
         -t ${FLATPAK_DEST}/share/metainfo/
@@ -52,6 +56,8 @@ modules:
         sha256: 9ce204945a22cb88be860dba1141c896f927982bca0940e1f08f87333a9556db
       - type: file
         path: xdg-mime.sh
+      - type: file
+        path: NOTICE.txt
       - type: file
         path: com.fightcade.Fightcade.Steamos.metainfo.xml
       - type: script

--- a/com.fightcade.Fightcade.Steamos.yml
+++ b/com.fightcade.Fightcade.Steamos.yml
@@ -31,6 +31,8 @@ modules:
     build-commands:
       # Install the run script for the Min browser
       - install -Dm755 run.sh ${FLATPAK_DEST}/bin/min-browser
+      # Install xdg-mime shim
+      - install -Dm755 xdg-mime.sh ${FLATPAK_DEST}/bin/xdg-mime
       # Install the browser
       - bsdtar -xOf min.deb data.tar.xz | bsdtar -xJf -
       - mv opt/Min min
@@ -48,6 +50,8 @@ modules:
           - x86_64
         url: https://github.com/minbrowser/min/releases/download/v1.35.0/min-1.35.0-amd64.deb
         sha256: 6d066842e8d0f0fa9aad0bd7cb5f56a32a67937ac75e8710c3b229cbcfc89220
+      - type: file
+        path: xdg-mime.sh
       - type: file
         path: com.fightcade.Fightcade.Steamos.metainfo.xml
       - type: script

--- a/xdg-mime.sh
+++ b/xdg-mime.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Shim script for xdg-mime.
+
+if [[ "$1" == "query" && "$2" == "default" && "$3" == "x-scheme-handler/fcade" ]]; then
+  echo "com.fightcade.Fightcade.fcade-quark.desktop"
+  exit 0
+fi


### PR DESCRIPTION
### 📝 **Pull Request Description:**

This PR introduces support for Min Browser within the Fightcade SteamOS addon to handle external links in Gaming Mode, while ensuring full license compliance and compatibility with the Flatpak sandbox.

#### 🔄 Changes Included:

* 🔼 **Updated Min Browser to v1.35.1**

  * Latest release version from upstream GitHub repo.

* 🛠️ **Added xdg-mime shim**

  * Implements a workaround for Flatpak sandbox limitations, allowing `xdg-open` integration via custom handler.

* 📄 **Added Apache 2.0 license and NOTICE.txt**

  * Ensures compliance with the Apache License 2.0 as required by the Min project.
  * Both license text and NOTICE file are bundled.

* 🧾 **Updated `com.fightcade.Fightcade.Steamos.metainfo.xml`**

  * Declares the dual license: `GPL-3.0-or-later AND Apache-2.0`.
  * Adds mention of Min Browser and its license in the description.
